### PR TITLE
hunter.sh checks for history.txt and src/.env ./hunter.sh --run is called.

### DIFF
--- a/hunter.sh
+++ b/hunter.sh
@@ -23,6 +23,12 @@ build_image() {
 
 # Run the Docker container
 run_container() {
+    if ! test -f $(pwd)/history.txt; then
+        touch $(pwd)/history.txt
+    fi
+    if ! test -f $(pwd)/src/.env; then
+        touch $(pwd)/src/.env
+    fi
     docker run -it --rm --name groningen-hunter-container \
         -v $(pwd)/src/.env:/app/src/.env \
         -v $(pwd)/history.txt:/app/history.txt \


### PR DESCRIPTION
When `./hunter.sh --run` is called without creating a `history.txt` or a `src/.env`, the docker run command would create empty directorys for `history.txt` or `src/.env`. To fix this, hunter.sh can check to see if `history.txt` or `src/.env` exists, and if not creates the files.

## Steps to recreate the issue.
* Delete `history.txt` if it exists.
* `./hunter.sh --run`

If `history.txt` doesn't exist and `src/.env` is properly configured, the following error would occur.
```
Start hunters
Exception in thread Thread-1 (run_hunters):
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
  File "/app/src/main.py", line 126, in run_hunters
    history = History('history.txt')
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/app/src/history.py", line 4, in __init__
    self.seen_apartments = self.load_history()
                           ^^^^^^^^^^^^^^^^^^^
  File "/app/src/history.py", line 8, in load_history
    with open(self.file_path, 'r') as file:
         ^^^^^^^^^^^^^^^^^^^^^^^^^
IsADirectoryError: [Errno 21] Is a directory: 'history.txt'
```